### PR TITLE
fix: Enable quiet mode for concrete network version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -110,7 +110,7 @@ runs:
         solo network deploy -i node1,node2,node3 --deployment $SOLO_DEPLOYMENT
 
         # Setup nodes
-        solo node setup -i node1,node2,node3 --deployment $SOLO_DEPLOYMENT -t $HEDERA_VERSION
+        solo node setup -i node1,node2,node3 --deployment $SOLO_DEPLOYMENT -t $HEDERA_VERSION --quiet-mode
 
         # Start nodes
         solo node start -i node1,node2,node3 --deployment $SOLO_DEPLOYMENT


### PR DESCRIPTION
**Description**:

Adds quiet mode to avoid runner having to chose default version or the one specified by the config.

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-solo-action/issues/43

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
