### PR TITLE
feat: forward grpc web proxy port in dual mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A good example on how the action is used can be found at the [hiero-enterprise p
 The GitHub action takes the following inputs:
 
 | Input                    | Required | Default    | Description                                                                                                                                |
-|--------------------------|----------|------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------ | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `hbarAmount`             | false    | `10000000` | Amount of hbars to fund a created account with.                                                                                            |
 | `hieroVersion`           | false    | `v0.58.10` | Hiero consenus node version to use                                                                                                         |
 | `mirrorNodeVersion`      | false    | `v0.133.0` | Mirror node version to use                                                                                                                 |
@@ -31,6 +31,7 @@ The GitHub action takes the following inputs:
 | `installRelay`           | false    | `false`    | If set to `true`, the action will install the JSON-RPC-Relay as part of the setup process.                                                 |
 | `relayPort`              | false    | `7546`     | Port for the JSON-RPC-Relay                                                                                                                |
 | `grpcProxyPort`          | false    | `9998`     | Port for gRPC Proxy                                                                                                                        |
+| `dualModeGrpcProxyPort`  | false    | `9999`     | Port for the gRPC Proxy of the second consensus node (only if dual mode is enabled)                                                        |
 | `haproxyPort`            | false    | `50211`    | Port for HAProxy                                                                                                                           |
 | `soloVersion`            | false    | `0.41.0`   | Version of Solo CLI to install                                                                                                             |
 | `javaRestApiPort`        | false    | `8084`     | Port for Java-based REST API                                                                                                               |
@@ -89,7 +90,7 @@ The GitHub action takes the following inputs:
 - name: Setup Hiero Solo
   uses: hiero-ledger/hiero-solo-action@v0.8
   id: solo
-  
+
 - name: Use Hiero Solo
   run: |
     echo "Account ID: ${{ steps.solo.outputs.ed25519AccountId }}"
@@ -121,7 +122,7 @@ The GitHub action takes the following inputs:
   id: solo
   with:
     dualMode: true
-    
+
 - name: Verify Nodes
   run: |
     echo "Checking services for both nodes..."

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: "Port for gRPC Proxy"
     required: false
     default: "9998"
+  dualModeGrpcProxyPort:
+    description: "Port for the gRPC Proxy of the second consensus node (only if dual mode is enabled)"
+    required: false
+    default: "9999"
   haproxyPort:
     description: "Port for HAProxy"
     required: false
@@ -248,13 +252,22 @@ runs:
           echo "HAProxy service haproxy-node1-svc not found, skipping port-forward"
         fi
 
-        # Port forward HAProxy for node2 if dual mode is enabled (only if service exists)
+        # Port forward services for node2 if dual mode is enabled
         if [[ "${DUAL_MODE}" == "true" ]]; then
+          # Port forward HAProxy for node2 (only if service exists)
           if kubectl get svc haproxy-node2-svc -n ${SOLO_NAMESPACE} >/dev/null 2>&1; then
             kubectl port-forward svc/haproxy-node2-svc -n ${SOLO_NAMESPACE} 51211:50211 &
             echo "HAProxy for node2 is accessible on port 51211"
           else
             echo "HAProxy service haproxy-node2-svc not found, skipping port-forward"
+          fi
+
+          # Port forward gRPC proxy for node2 (only if service exists)
+          if kubectl get svc envoy-proxy-node2-svc -n ${SOLO_NAMESPACE} >/dev/null 2>&1; then
+            kubectl port-forward svc/envoy-proxy-node2-svc -n ${SOLO_NAMESPACE} ${{ inputs.dualModeGrpcProxyPort }}:8080 &
+            echo "gRPC proxy for node2 is accessible on port ${{ inputs.dualModeGrpcProxyPort }}"
+          else
+            echo "gRPC proxy service envoy-proxy-node2-svc not found, skipping port-forward"
           fi
         fi
 
@@ -263,16 +276,6 @@ runs:
           kubectl port-forward svc/envoy-proxy-node1-svc -n ${SOLO_NAMESPACE} ${{ inputs.grpcProxyPort }}:8080 &
         else
           echo "gRPC proxy service envoy-proxy-node1-svc not found, skipping port-forward"
-        fi
-
-        # Port forward gRPC proxy for node2 if dual mode is enabled (only if service exists)
-        if [[ "${DUAL_MODE}" == "true" ]]; then
-          if kubectl get svc envoy-proxy-node2-svc -n ${SOLO_NAMESPACE} >/dev/null 2>&1; then
-            kubectl port-forward svc/envoy-proxy-node2-svc -n ${SOLO_NAMESPACE} 8081:8080 &
-            echo "gRPC proxy for node2 is accessible on port 8081"
-          else
-            echo "gRPC proxy service envoy-proxy-node2-svc not found, skipping port-forward"
-          fi
         fi
 
     - name: Deploy MirrorNode


### PR DESCRIPTION
**Description**:
This forwards the grpc proxy port of node 2 if dual mode is enabled.
Also adds the domains of the grpc proxies to etc/hosts so they're resolved to localhost.
Fixes: https://github.com/hiero-ledger/hiero-solo-action/issues/116
