### PR TITLE
feat: add highThrottle input to use high-throughput genesis throttles

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,11 @@ inputs:
     required: false
     default: false
     type: boolean
+  highThrottle:
+    description: "Use a high-throughput throttles.json at network genesis (100x default limits)"
+    required: false
+    default: false
+    type: boolean
   hbarAmount:
     description: "Amount of HBAR to be assigned to the created accounts"
     required: false
@@ -164,6 +169,8 @@ runs:
         HIERO_VERSION: ${{ inputs.hieroVersion }}
         SOLO_GE_0440: ${{ steps.check-solo-version.outputs.solo-ge-0440 }}
         DUAL_MODE: ${{ inputs.dualMode }}
+        HIGH_THROTTLE: ${{ inputs.highThrottle }}
+        GITHUB_ACTION_PATH: ${{ github.action_path }}
       run: |
         # Create a Kubernetes cluster using kind
         kind create cluster -n ${SOLO_CLUSTER_NAME}
@@ -178,6 +185,13 @@ runs:
         else
           NUM_NODES=1
           NODE_IDS="node1"
+        fi
+
+        # Opt-in high-throughput throttles for genesis
+        THROTTLES_FLAG=""
+        if [[ "${HIGH_THROTTLE}" == "true" ]]; then
+          THROTTLES_FLAG="--genesis-throttles-file ${GITHUB_ACTION_PATH}/high-throttles.json"
+          echo "Using high-throughput throttles from ${GITHUB_ACTION_PATH}/high-throttles.json"
         fi
 
         echo "Deploying ${NUM_NODES} consensus node(s)..."
@@ -199,7 +213,7 @@ runs:
           solo cluster-ref config setup -s ${SOLO_CLUSTER_NAME} --dev
 
           # Deploy network
-          solo consensus network deploy -i ${NODE_IDS} --deployment ${SOLO_DEPLOYMENT} --release-tag ${HIERO_VERSION} --dev
+          solo consensus network deploy -i ${NODE_IDS} --deployment ${SOLO_DEPLOYMENT} --release-tag ${HIERO_VERSION} ${THROTTLES_FLAG} --dev
 
           # Setup and start nodes
           solo consensus node setup -i ${NODE_IDS} --deployment ${SOLO_DEPLOYMENT} --release-tag ${HIERO_VERSION} --quiet-mode --dev
@@ -216,7 +230,7 @@ runs:
           solo cluster-ref setup -s ${SOLO_CLUSTER_NAME} --dev
           
           # Deploy network
-          solo network deploy -i ${NODE_IDS} --deployment ${SOLO_DEPLOYMENT} --release-tag ${HIERO_VERSION} --dev
+          solo network deploy -i ${NODE_IDS} --deployment ${SOLO_DEPLOYMENT} --release-tag ${HIERO_VERSION} ${THROTTLES_FLAG} --dev
           
           # Setup and start nodes
           solo node setup -i ${NODE_IDS} --deployment ${SOLO_DEPLOYMENT} --release-tag ${HIERO_VERSION} --quiet-mode --dev

--- a/high-throttles.json
+++ b/high-throttles.json
@@ -1,0 +1,171 @@
+{
+  "buckets": [
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 5000,
+      "name": "ThroughputLimits",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 10000000,
+          "operations": [
+            "ScheduleCreate",
+            "CryptoCreate",
+            "CryptoTransfer",
+            "CryptoUpdate",
+            "CryptoDelete",
+            "CryptoGetInfo",
+            "CryptoGetAccountRecords",
+            "ConsensusCreateTopic",
+            "ConsensusSubmitMessage",
+            "ConsensusUpdateTopic",
+            "ConsensusDeleteTopic",
+            "ConsensusGetTopicInfo",
+            "TokenGetNftInfo",
+            "TokenGetInfo",
+            "ScheduleDelete",
+            "ScheduleGetInfo",
+            "FileGetContents",
+            "FileGetInfo",
+            "ContractUpdate",
+            "ContractDelete",
+            "ContractGetInfo",
+            "ContractGetBytecode",
+            "ContractGetRecords",
+            "ContractCallLocal",
+            "TransactionGetRecord",
+            "GetVersionInfo",
+            "TokenGetAccountNftInfos",
+            "TokenGetNftInfos",
+            "CryptoApproveAllowance",
+            "CryptoDeleteAllowance",
+            "UtilPrng",
+            "NodeCreate",
+            "NodeUpdate",
+            "NodeDelete",
+            "AtomicBatch"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 100000,
+          "operations": ["ScheduleSign"]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 500000,
+          "operations": ["TokenMint"]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 300000,
+          "operations": ["ContractCall", "ContractCreate", "EthereumTransaction"]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 500000,
+          "operations": [
+            "TokenDelete",
+            "TokenBurn",
+            "TokenUpdate",
+            "TokenFeeScheduleUpdate",
+            "TokenAccountWipe",
+            "TokenDissociateFromAccount",
+            "TokenFreezeAccount",
+            "TokenUnfreezeAccount",
+            "TokenGrantKycToAccount",
+            "TokenRevokeKycFromAccount",
+            "TokenPause",
+            "TokenUnpause",
+            "TokenUpdateNfts",
+            "TokenReject",
+            "TokenAirdrop",
+            "TokenCancelAirdrop",
+            "TokenClaimAirdrop"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 100000,
+          "operations": ["HookStore"]
+        }
+      ]
+    },
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 5000,
+      "name": "OffHeapQueryLimits",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 500000,
+          "operations": [
+            "FileGetContents",
+            "FileGetInfo",
+            "ContractGetInfo",
+            "ContractGetBytecode",
+            "ContractCallLocal"
+          ]
+        }
+      ]
+    },
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 5000,
+      "name": "PriorityReservations",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 200000,
+          "operations": ["FileCreate", "FileUpdate", "FileAppend", "FileDelete"]
+        }
+      ]
+    },
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 5000,
+      "name": "CreationLimits",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 1000000,
+          "operations": ["CryptoCreate", "NodeCreate"]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 200000,
+          "operations": ["ConsensusCreateTopic"]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 500000,
+          "operations": ["TokenCreate", "TokenAssociateToAccount", "ScheduleCreate", "TokenAirdrop"]
+        }
+      ]
+    },
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 5000,
+      "name": "FreeQueryLimits",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 25000000,
+          "operations": ["TransactionGetReceipt"]
+        }
+      ]
+    },
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 5000,
+      "name": "BalanceQueryLimits",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 10000000,
+          "operations": ["CryptoGetAccountBalance"]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds an opt-in `highThrottle` boolean input. When set, the action passes `--genesis-throttles-file high-throttles.json` to `solo ... network deploy` so the local network starts with 100x default throttle limits.

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
