### PR TITLE
feat: add CI pipeline for local setup validation

### DIFF
--- a/.github/workflows/validate-local-setup.yml
+++ b/.github/workflows/validate-local-setup.yml
@@ -1,0 +1,103 @@
+name: Validate Local Setup
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'local/**'
+      - 'extractAccountAsJson.py'
+      - '.github/workflows/validate-local-setup.yml'
+
+jobs:
+  validate-dockerfile-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: 🚀 Checkout Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: 🔨 Build Docker Image
+        working-directory: local
+        run: docker build -t hiero/solo-runner . --build-context gh=..
+
+  validate-docker-compose:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: 🚀 Checkout Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: ⚙️ Run Docker Compose Setup
+        working-directory: local
+        run: docker compose up --build --exit-code-from solo-test-cluster
+
+      - name: ✅ Validate HAProxy Connectivity
+        run: |
+          echo "Checking HAProxy on port 50211..."
+          nc -z localhost 50211 && echo "HAProxy is accessible at localhost:50211"
+
+  validate-plain-docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: 🚀 Checkout Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: 🔨 Build Docker Image
+        working-directory: local
+        run: docker build -t hiero/solo-runner . --build-context gh=..
+
+      - name: ⚙️ Run Docker Container
+        run: docker run -v /var/run/docker.sock:/var/run/docker.sock --network host hiero/solo-runner
+
+      - name: ✅ Validate HAProxy Connectivity
+        run: |
+          echo "Checking HAProxy on port 50211..."
+          nc -z localhost 50211 && echo "HAProxy is accessible at localhost:50211"
+
+  validate-local-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: 🚀 Checkout Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: ✅ Validate Documentation Completeness
+        run: |
+          echo "Checking local/README.md content..."
+          grep -q "Docker Compose" local/README.md
+          grep -q "Plain Docker" local/README.md
+          grep -q "50211" local/README.md
+          echo "Checking referenced scripts exist..."
+          test -f local/all-in-setup.sh
+          test -f local/setup-solo-test-net.sh
+          test -f local/create-ecdsa-account.sh
+          test -f local/kind-config.yaml
+          test -f local/haproxy-svc-patch.yaml
+          test -f extractAccountAsJson.py
+          echo "✅ All documentation checks passed"


### PR DESCRIPTION
Closes #107

## Summary

- Adds `.github/workflows/validate-local-setup.yml` to test the `local/` Docker-based setup which had zero CI coverage
- Workflow is path-scoped — only triggers on changes to `local/**`, `extractAccountAsJson.py`, or the workflow file itself
- `concurrency` block cancels stale runs on new pushes, preventing wasted minutes on the 60-minute jobs

## Jobs

| Job | What it tests | Timeout |
| :--- | :--- | :--- |
| `validate-dockerfile-build` | Docker image builds cleanly (all downloads succeed, Dockerfile syntax valid) | — |
| `validate-docker-compose` | `docker compose up --build` completes + HAProxy accessible on `localhost:50211` | 60 min |
| `validate-plain-docker` | Manual `docker build` + `docker run` completes + HAProxy accessible on `localhost:50211` | 60 min |
| `validate-local-docs` | `local/README.md` documents both methods, all referenced scripts exist | — |

## Notes

- Matches `validation.yml` conventions exactly: same pinned `step-security/harden-runner` and `actions/checkout` hashes, `egress-policy: audit`, same emoji step naming
- `validate-docker-compose` and `validate-plain-docker` run on separate fresh runners so kind cluster names never conflict
- Both long-running jobs share the same connectivity check: after the container exits, the kind cluster persists on the host Docker daemon (socket was shared via `-v /var/run/docker.sock`) so `nc -z localhost 50211` is valid post-run validation
- There is a pre-existing version mismatch in `local/Dockerfile` (`solo@0.39.0`) vs `local/create-ecdsa-account.sh` which calls `solo ledger account create` — a command that only exists in solo ≥ 0.44.0. The compose and plain-docker jobs will surface this failure correctly. Fixing the Dockerfile version is a separate concern.

## Test Plan

- [x] `validate-dockerfile-build` passes on PR open
- [x] `validate-local-docs` passes on PR open
- [ ] `validate-docker-compose` runs and fails at `create-ecdsa-account.sh` (expected — surfaces pre-existing bug)
- [ ] `validate-plain-docker` runs and fails at `create-ecdsa-account.sh` (expected — surfaces pre-existing bug)
- [ ] Pushing a second commit cancels the still-running first run (concurrency check)
