### PR TITLE
Add nodeVersion input for Solo CLI installation

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - name: 🚀 Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: ⚙️ Setup Hiero Solo
         id: solo
@@ -40,12 +40,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - name: 🚀 Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: ⚙️ Setup Hiero Solo
         id: solo
@@ -70,12 +70,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - name: 🚀 Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: ⚙️ Setup Hiero Solo
         id: solo
@@ -92,12 +92,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - name: 🚀 Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: ⚙️ Setup Hiero Solo with Block Node
         id: solo
@@ -135,12 +135,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - name: 🚀 Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: ⚙️ Setup Hiero Solo with MirrorNode
         id: solo
@@ -180,12 +180,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - name: 🚀 Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: ⚙️ Setup Hiero Solo with JSON-RPC Relay
         id: solo
@@ -272,12 +272,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - name: 🚀 Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: ⚙️ Setup Hiero Solo
         id: solo
@@ -301,12 +301,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - name: 🚀 Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: ⚙️ Setup Hiero Solo with Mirror Node
         id: solo

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The GitHub action takes the following inputs:
 | `haproxyPort`            | false    | `35211`    | Port for HAProxy (consensus node gRPC)                                                                                                     |
 | `soloVersion`            | false    | `0.69.0`   | Version of Solo CLI to install                                                                                                             |
 | `javaRestApiPort`        | false    | `8084`     | Port for Java-based REST API                                                                                                               |
+| `nodeVersion`            | false    | `24`       | Node.js version to use for Solo CLI installation. Must be 22 or higher.                                                                    |
 | `dualMode`               | false    | `false`    | Enable dual mode to deploy two consensus nodes                                                                                             |
 
 > [! IMPORTANT]

--- a/action.yml
+++ b/action.yml
@@ -132,7 +132,7 @@ runs:
         java-version: 21
 
     - name: Setup Node
-      uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.nodeVersion }}
 

--- a/action.yml
+++ b/action.yml
@@ -126,7 +126,7 @@ runs:
         fi
 
     - name: Setup Java
-      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: temurin
         java-version: 21
@@ -141,12 +141,12 @@ runs:
       run: sudo apt-get update && sudo apt-get install -y wget
 
     - name: Install Python
-      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.10"
 
     - name: Setup Kind
-      uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
       with:
         install_only: true
         node_image: kindest/node:v1.32.2@sha256:3966f21e12b760f6585bde7140cae5e8cdc0e52b37a6f90ce39834b6e72e3f49

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,10 @@ inputs:
     required: false
     default: false
     type: boolean
+  nodeVersion:
+    description: "Node.js version to use for Solo CLI installation"
+    required: false
+    default: "24"
   hbarAmount:
     description: "Amount of HBAR to be assigned to the created accounts"
     required: false
@@ -111,6 +115,16 @@ runs:
         echo "installBlockNode: ${{ inputs.installBlockNode }}"
         echo "is installBlockNode: ${{ inputs.installBlockNode == 'true' }}"
 
+    - name: Validate Node.js version
+      shell: bash
+      run: |
+        NODE_VERSION="${{ inputs.nodeVersion }}"
+        MAJOR_VERSION=$(echo "${NODE_VERSION}" | grep -oE '^[0-9]+')
+        if [ -z "${MAJOR_VERSION}" ] || [ "${MAJOR_VERSION}" -lt 22 ]; then
+          echo "::error::Node.js version must be 22 or higher. Solo does not support Node.js < 22. Got: ${NODE_VERSION}"
+          exit 1
+        fi
+
     - name: Setup Java
       uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with:
@@ -120,7 +134,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
       with:
-        node-version: 22
+        node-version: ${{ inputs.nodeVersion }}
 
     - name: Install WGet CLI
       shell: bash


### PR DESCRIPTION
**Description**:

Add support for configuring the Node.js version used to install the Solo CLI in the GitHub Action, ensuring compatibility with Solo's requirements. Introduces a new input for specifying the Node.js version, validates that the version is 22 or higher


* Added a new `nodeVersion` input to `action.yml` and updated the README to allow users to specify the Node.js version for Solo CLI installation, with a default of `24` and a requirement that it must be 22 or higher.
* Implemented a validation step in the workflow to ensure the specified Node.js version is at least 22.
**Workflow Configuration:**

* Modified the Node.js setup step to use the user-specified `nodeVersion` input instead of a hardcoded value.
* Updates the setup dependencies to the latest

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-solo-action/issues/139

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
