### PR TITLE
Expose raw ED25519 private key alongside existing DER output

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -33,6 +33,7 @@ jobs:
           ECDSA_PUBLIC_KEY: ${{ steps.solo.outputs.ecdsaPublicKey }}
           ED25519_ACCOUNT_ID: ${{ steps.solo.outputs.ed25519AccountId }}
           ED25519_PRIVATE_KEY: ${{ steps.solo.outputs.ed25519PrivateKey }}
+          ED25519_PRIVATE_KEY_RAW: ${{ steps.solo.outputs.ed25519PrivateKeyRaw }}
           ED25519_PUBLIC_KEY: ${{ steps.solo.outputs.ed25519PublicKey }}
         run: ${GITHUB_WORKSPACE}/scripts/check-accounts.sh
 
@@ -63,6 +64,7 @@ jobs:
           ECDSA_PUBLIC_KEY: ${{ steps.solo.outputs.ecdsaPublicKey }}
           ED25519_ACCOUNT_ID: ${{ steps.solo.outputs.ed25519AccountId }}
           ED25519_PRIVATE_KEY: ${{ steps.solo.outputs.ed25519PrivateKey }}
+          ED25519_PRIVATE_KEY_RAW: ${{ steps.solo.outputs.ed25519PrivateKeyRaw }}
           ED25519_PUBLIC_KEY: ${{ steps.solo.outputs.ed25519PublicKey }}
         run: ${GITHUB_WORKSPACE}/scripts/check-accounts.sh
 
@@ -203,6 +205,7 @@ jobs:
           ECDSA_PUBLIC_KEY: ${{ steps.solo.outputs.ecdsaPublicKey }}
           ED25519_ACCOUNT_ID: ${{ steps.solo.outputs.ed25519AccountId }}
           ED25519_PRIVATE_KEY: ${{ steps.solo.outputs.ed25519PrivateKey }}
+          ED25519_PRIVATE_KEY_RAW: ${{ steps.solo.outputs.ed25519PrivateKeyRaw }}
           ED25519_PUBLIC_KEY: ${{ steps.solo.outputs.ed25519PublicKey }}
         run: |
           ${GITHUB_WORKSPACE}/scripts/check-accounts.sh

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The GitHub action takes the following inputs:
 | -------------------------------------- | ---------------------------------------------------------- |
 | `steps.solo.outputs.accountId`         | The account ID of account created in ED25519 format.       |
 | `steps.solo.outputs.publicKey`         | The public key of account created in ED25519 format.       |
-| `steps.solo.outputs.privateKey`        | The private key of account created in ED25519 format.      |
+| `steps.solo.outputs.privateKey`        | The private key of account created in ED25519 format (DER-encoded hex, `302e...`). |
 | `steps.solo.outputs.deployment`        | The name of the Solo deployment created by the action.     |
 | `steps.solo.outputs.ecdsaAccountId`    | The account ID of the account created (in ECDSA format).   |
 | `steps.solo.outputs.ecdsaPublicKey`    | The public key of the account created (in ECDSA format).   |
@@ -69,6 +69,7 @@ The GitHub action takes the following inputs:
 | `steps.solo.outputs.ed25519AccountId`  | Same as `accountId`, but with an explicit ED25519 format!  |
 | `steps.solo.outputs.ed25519PublicKey`  | Same as `publicKey`, but with an explicit ED25519 format!  |
 | `steps.solo.outputs.ed25519PrivateKey` | Same as `privateKey`, but with an explicit ED25519 format! |
+| `steps.solo.outputs.ed25519PrivateKeyRaw` | Raw 32-byte ED25519 private key as hex (64 characters). |
 
 # Simple usage
 
@@ -109,6 +110,7 @@ The GitHub action takes the following inputs:
   run: |
     echo "Account ID: ${{ steps.solo.outputs.ed25519AccountId }}"
     echo "Private Key: ${{ steps.solo.outputs.ed25519PrivateKey }}"
+    echo "Private Key (raw): ${{ steps.solo.outputs.ed25519PrivateKeyRaw }}"
     echo "Public Key: ${{ steps.solo.outputs.ed25519PublicKey }}"
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ outputs:
     description: "Public key of the generated ED25519 account (default for simplicity)"
     value: ${{ steps.create-ed25519.outputs.publicKey }}
   privateKey:
-    description: "Private key of the generated ED25519 account (default for simplicity)"
+    description: "Private key of the generated ED25519 account in DER-encoded hex (default for simplicity)"
     value: ${{ steps.create-ed25519.outputs.privateKey }}
   deployment:
     description: "Name of the Solo deployment created by the action"
@@ -102,8 +102,11 @@ outputs:
     description: "ED25519 public key of generated account"
     value: ${{ steps.create-ed25519.outputs.publicKey }}
   ed25519PrivateKey:
-    description: "ED25519 private key of generated account"
+    description: "ED25519 private key of generated account (DER-encoded hex)"
     value: ${{ steps.create-ed25519.outputs.privateKey }}
+  ed25519PrivateKeyRaw:
+    description: "ED25519 private key of generated account (raw 32-byte hex)"
+    value: ${{ steps.create-ed25519.outputs.privateKeyRaw }}
 runs:
   using: "composite"
   steps:
@@ -479,6 +482,13 @@ runs:
         export ACCOUNT_PUBLIC_KEY=$(echo ${JSON} | jq -r '.publicKey')
         export ACCOUNT_PRIVATE_KEY=$(kubectl get secret account-key-${ACCOUNT_ID} -n ${SOLO_NAMESPACE} -o jsonpath='{.data.privateKey}' | base64 -d | xargs)
 
+        ED25519_DER_PREFIX="302e020100300506032b657004220420"
+        export ACCOUNT_PRIVATE_KEY_RAW="${ACCOUNT_PRIVATE_KEY#${ED25519_DER_PREFIX}}"
+        if [[ ${#ACCOUNT_PRIVATE_KEY_RAW} -ne 64 ]]; then
+          echo "Error: Failed to derive raw ED25519 private key from DER format"
+          exit 1
+        fi
+
         if [[ "${SOLO_GE_0440}" == "true" ]]; then
           solo ledger account update --account-id "${ACCOUNT_ID}" --hbar-amount "${HBAR_AMOUNT}" --deployment "${SOLO_DEPLOYMENT}" --dev
         else
@@ -488,9 +498,11 @@ runs:
         echo "accountId=${ACCOUNT_ID}"
         echo "publicKey=${ACCOUNT_PUBLIC_KEY}"
         echo "privateKey=${ACCOUNT_PRIVATE_KEY}"
+        echo "privateKeyRaw=${ACCOUNT_PRIVATE_KEY_RAW}"
         echo "accountId=${ACCOUNT_ID}" >> ${GITHUB_OUTPUT}
         echo "publicKey=${ACCOUNT_PUBLIC_KEY}" >> ${GITHUB_OUTPUT}
         echo "privateKey=${ACCOUNT_PRIVATE_KEY}" >> ${GITHUB_OUTPUT}
+        echo "privateKeyRaw=${ACCOUNT_PRIVATE_KEY_RAW}" >> ${GITHUB_OUTPUT}
 
 # Ref: https://haya14busa.github.io/github-action-brandings/
 branding:

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ inputs:
   soloVersion:
     description: "Version of Solo CLI to install"
     required: false
-    default: "0.74.0"
+    default: "0.81.0"
   javaRestApiPort:
     description: "Port for Java-based REST API"
     required: false

--- a/scripts/check-accounts.sh
+++ b/scripts/check-accounts.sh
@@ -43,5 +43,17 @@ if [ -z "$ED25519_PUBLIC_KEY" ]; then
     echo "❌ Error: ED25519 publicKey is missing!"
     exit 1
 fi
+if [ -z "$ED25519_PRIVATE_KEY_RAW" ]; then
+    echo "❌ Error: ED25519 privateKeyRaw is missing!"
+    exit 1
+fi
+if [ ${#ED25519_PRIVATE_KEY_RAW} -ne 64 ]; then
+    echo "❌ Error: ED25519 privateKeyRaw must be 64 hex characters!"
+    exit 1
+fi
+if [ "${ED25519_PRIVATE_KEY: -64}" != "$ED25519_PRIVATE_KEY_RAW" ]; then
+    echo "❌ Error: ED25519 privateKeyRaw does not match the DER private key!"
+    exit 1
+fi
 
 echo "🎉 All outputs are valid!"


### PR DESCRIPTION
**Description**:

Adds a new ed25519PrivateKeyRaw output to solo-action for SDKs that expect a raw 32-byte hex Ed25519 private key instead of the DER-encoded format (302e...).

Previously, the action only exposed privateKey / ed25519PrivateKey from the Solo Kubernetes secret, which stores keys in DER hex. Some SDKs (e.g. the Dart SDK) only support raw hex keys today, so consumers may have to manually strip the DER prefix in their workflows.

This change derives the raw key during ED25519 account creation and exposes it as steps.solo.outputs.ed25519PrivateKeyRaw.


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
