### PR TITLE
chore: update solo version to 0.82.1

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -105,7 +105,7 @@ jobs:
         id: solo
         uses: ./
         with:
-          soloVersion: v0.69.0
+          soloVersion: v0.69.1
           installBlockNode: true
           hieroVersion: 'v0.73.0'
 

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ inputs:
   soloVersion:
     description: "Version of Solo CLI to install"
     required: false
-    default: "0.81.0"
+    default: "0.82.1"
   javaRestApiPort:
     description: "Port for Java-based REST API"
     required: false


### PR DESCRIPTION
## Summary
- Bumps this action's own default `soloVersion` from `0.81.0` to `0.82.1` in `action.yml`.
- Bumps the hardcoded `soloVersion` in `validation.yml`'s block-node self-test job from `v0.69.0` to `v0.69.1`.
- The pre-0.44.0 compatibility job's hardcoded `soloVersion: '0.43.2'` is intentionally left unchanged.